### PR TITLE
Rename Modules, Update Links, and Relocate Dispatcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -494,55 +494,55 @@ generate-zk-keys:
 .PHONY: generate-zk-keys
 
 ######################################################################
-#######                     Relayer                       ############
+#######                     dispatcher                       ############
 ######################################################################
 
-run-alice-relayer:
-	zkappd tx zk-gov run-relayer --from alice --keyring-backend test --chain-id demo -y
-run-bob-relayer:
-	zkappd tx zk-gov run-relayer --from bob --keyring-backend test --chain-id demo
-run-sai-relayer:
-	zkappd tx zk-gov run-relayer --from sai --keyring-backend test --chain-id demo
-run-teja-relayer:
-	zkappd tx zk-gov run-relayer --from teja --keyring-backend test --chain-id demo
+run-vishal-dispatcher:
+	zkappd tx zk-gov run-dispatcher --from vishal --keyring-backend test --chain-id demo -y
+run-kanna-dispatcher:
+	zkappd tx zk-gov run-dispatcher --from kanna --keyring-backend test --chain-id demo
+run-sai-dispatcher:
+	zkappd tx zk-gov run-dispatcher --from sai --keyring-backend test --chain-id demo
+run-teja-dispatcher:
+	zkappd tx zk-gov run-dispatcher --from teja --keyring-backend test --chain-id demo
 
-.PHONY: run-alice-relayer run-bob-relayer run-sai-relayer run-teja-relayer
+.PHONY: run-vishal-dispatcher run-kanna-dispatcher run-sai-dispatcher run-teja-dispatcher
 
 ######################################################################
 #######                  Transactions                     ############
 ######################################################################
 
 create-proposal-a: 
-	zkappd tx zk-gov create-proposal "proposal-A" "proposal-A description" --from alice --keyring-backend test --chain-id demo
+	zkappd tx zk-gov create-proposal "proposal-A" "proposal-A description" --from vishal --keyring-backend test --chain-id demo
 create-proposal-b: 
-	zkappd tx zk-gov create-proposal "proposal-B" "proposal-B description" --from alice --keyring-backend test --chain-id demo
+	zkappd tx zk-gov create-proposal "proposal-B" "proposal-B description" --from vishal --keyring-backend test --chain-id demo
 
-register-alice-vote: 
-	zkappd tx zk-gov register-vote 1 "NO" --from alice --keyring-backend test --chain-id demo
-register-bob-vote: 
-	zkappd tx zk-gov register-vote 1 "YES" --from bob --keyring-backend test --chain-id demo
+register-vishal-vote: 
+	zkappd tx zk-gov register-vote 1 "NO" --from vishal --keyring-backend test --chain-id demo
+register-kanna-vote: 
+	zkappd tx zk-gov register-vote 1 "YES" --from kanna --keyring-backend test --chain-id demo
 register-sai-vote: 
 	zkappd tx zk-gov register-vote 1 "NO" --from sai --keyring-backend test --chain-id demo
 register-teja-vote: 
 	zkappd tx zk-gov register-vote 1 "YES" --from teja --keyring-backend test --chain-id demo
 
-broadcast-alice-vote:
+broadcast-vishal-vote:
 	zkappd tx zk-gov vote 1 cosmos1ux2hl3y42nz6vtdl8k7t7f05k9p3r2k62zfvtv --from unknown --keyring-backend test --chain-id demo
-broadcast-bob-vote:
+broadcast-kanna-vote:
 	zkappd tx zk-gov vote 1 cosmos13j3mn8n2d3scd2yy3urmw5vqhn53rej6p050np --from unknown --keyring-backend test --chain-id demo
 broadcast-sai-vote:
 	zkappd tx zk-gov vote 1 cosmos1mg4t0l2nc98vhjdmg6kzee5wh6uhx9jlfrgfu9 --from unknown --keyring-backend test --chain-id demo
 broadcast-teja-vote:
 	zkappd tx zk-gov vote 1 cosmos1pf0m5ch2673r6lv5lwm2mkyw433xapzx7nuemu --from unknown --keyring-backend test --chain-id demo
 
-broadcast-alice-vote-via-relayer:
-	zkappd tx zk-gov vote 1 cosmos1ux2hl3y42nz6vtdl8k7t7f05k9p3r2k62zfvtv --relayer "http://localhost:8080"
-broadcast-bob-vote-via-relayer:
-	zkappd tx zk-gov vote 1 cosmos13j3mn8n2d3scd2yy3urmw5vqhn53rej6p050np --relayer "http://localhost:8080"
-broadcast-sai-vote-via-relayer:
-	zkappd tx zk-gov vote 1 cosmos1mg4t0l2nc98vhjdmg6kzee5wh6uhx9jlfrgfu9 --relayer "http://localhost:8080"
-broadcast-teja-vote-via-relayer:
-	zkappd tx zk-gov vote 1 cosmos1pf0m5ch2673r6lv5lwm2mkyw433xapzx7nuemu --relayer "http://localhost:8080"
+broadcast-vishal-vote-via-dispatcher:
+	zkappd tx zk-gov vote 1 cosmos1ux2hl3y42nz6vtdl8k7t7f05k9p3r2k62zfvtv --dispatcher "http://localhost:8080"
+broadcast-kanna-vote-via-dispatcher:
+	zkappd tx zk-gov vote 1 cosmos13j3mn8n2d3scd2yy3urmw5vqhn53rej6p050np --dispatcher "http://localhost:8080"
+broadcast-sai-vote-via-dispatcher:
+	zkappd tx zk-gov vote 1 cosmos1mg4t0l2nc98vhjdmg6kzee5wh6uhx9jlfrgfu9 --dispatcher "http://localhost:8080"
+broadcast-teja-vote-via-dispatcher:
+	zkappd tx zk-gov vote 1 cosmos1pf0m5ch2673r6lv5lwm2mkyw433xapzx7nuemu --dispatcher "http://localhost:8080"
 
 
-.PHONY: create-proposal-a create-proposal-b broadcast-alice-vote broadcast-bob-vote broadcast-sai-vote broadcast-teja-vote broadcast-alice-vote-via-relayer broadcast-bob-vote-via-relayer broadcast-sai-vote-via-relayer broadcast-teja-vote-via-relayer
+.PHONY: create-proposal-a create-proposal-b broadcast-vishal-vote broadcast-kanna-vote broadcast-sai-vote broadcast-teja-vote broadcast-vishal-vote-via-dispatcher broadcast-kanna-vote-via-dispatcher broadcast-sai-vote-via-dispatcher broadcast-teja-vote-via-dispatcher

--- a/Makefile
+++ b/Makefile
@@ -497,52 +497,52 @@ generate-zk-keys:
 #######                     dispatcher                       ############
 ######################################################################
 
-run-vishal-dispatcher:
-	zkappd tx zk-gov run-dispatcher --from vishal --keyring-backend test --chain-id demo -y
-run-kanna-dispatcher:
-	zkappd tx zk-gov run-dispatcher --from kanna --keyring-backend test --chain-id demo
-run-sai-dispatcher:
-	zkappd tx zk-gov run-dispatcher --from sai --keyring-backend test --chain-id demo
-run-teja-dispatcher:
-	zkappd tx zk-gov run-dispatcher --from teja --keyring-backend test --chain-id demo
+run-alice-dispatcher:
+	zkappd tx zk-gov run-dispatcher --from alice --keyring-backend test --chain-id demo -y
+run-bob-dispatcher:
+	zkappd tx zk-gov run-dispatcher --from bob --keyring-backend test --chain-id demo
+run-charlie-dispatcher:
+	zkappd tx zk-gov run-dispatcher --from charlie --keyring-backend test --chain-id demo
+run-david-dispatcher:
+	zkappd tx zk-gov run-dispatcher --from david --keyring-backend test --chain-id demo
 
-.PHONY: run-vishal-dispatcher run-kanna-dispatcher run-sai-dispatcher run-teja-dispatcher
+.PHONY: run-alice-dispatcher run-bob-dispatcher run-charlie-dispatcher run-david-dispatcher
 
 ######################################################################
 #######                  Transactions                     ############
 ######################################################################
 
 create-proposal-a: 
-	zkappd tx zk-gov create-proposal "proposal-A" "proposal-A description" --from vishal --keyring-backend test --chain-id demo
+	zkappd tx zk-gov create-proposal "proposal-A" "proposal-A description" --from alice --keyring-backend test --chain-id demo
 create-proposal-b: 
-	zkappd tx zk-gov create-proposal "proposal-B" "proposal-B description" --from vishal --keyring-backend test --chain-id demo
+	zkappd tx zk-gov create-proposal "proposal-B" "proposal-B description" --from alice --keyring-backend test --chain-id demo
 
-register-vishal-vote: 
-	zkappd tx zk-gov register-vote 1 "NO" --from vishal --keyring-backend test --chain-id demo
-register-kanna-vote: 
-	zkappd tx zk-gov register-vote 1 "YES" --from kanna --keyring-backend test --chain-id demo
-register-sai-vote: 
-	zkappd tx zk-gov register-vote 1 "NO" --from sai --keyring-backend test --chain-id demo
-register-teja-vote: 
-	zkappd tx zk-gov register-vote 1 "YES" --from teja --keyring-backend test --chain-id demo
+register-alice-vote: 
+	zkappd tx zk-gov register-vote 1 "NO" --from alice --keyring-backend test --chain-id demo
+register-bob-vote: 
+	zkappd tx zk-gov register-vote 1 "YES" --from bob --keyring-backend test --chain-id demo
+register-charlie-vote: 
+	zkappd tx zk-gov register-vote 1 "NO" --from charlie --keyring-backend test --chain-id demo
+register-david-vote: 
+	zkappd tx zk-gov register-vote 1 "YES" --from david --keyring-backend test --chain-id demo
 
-broadcast-vishal-vote:
+broadcast-alice-vote:
 	zkappd tx zk-gov vote 1 cosmos1ux2hl3y42nz6vtdl8k7t7f05k9p3r2k62zfvtv --from unknown --keyring-backend test --chain-id demo
-broadcast-kanna-vote:
+broadcast-bob-vote:
 	zkappd tx zk-gov vote 1 cosmos13j3mn8n2d3scd2yy3urmw5vqhn53rej6p050np --from unknown --keyring-backend test --chain-id demo
-broadcast-sai-vote:
+broadcast-charlie-vote:
 	zkappd tx zk-gov vote 1 cosmos1mg4t0l2nc98vhjdmg6kzee5wh6uhx9jlfrgfu9 --from unknown --keyring-backend test --chain-id demo
-broadcast-teja-vote:
+broadcast-david-vote:
 	zkappd tx zk-gov vote 1 cosmos1pf0m5ch2673r6lv5lwm2mkyw433xapzx7nuemu --from unknown --keyring-backend test --chain-id demo
 
-broadcast-vishal-vote-via-dispatcher:
+broadcast-alice-vote-via-dispatcher:
 	zkappd tx zk-gov vote 1 cosmos1ux2hl3y42nz6vtdl8k7t7f05k9p3r2k62zfvtv --dispatcher "http://localhost:8080"
-broadcast-kanna-vote-via-dispatcher:
+broadcast-bob-vote-via-dispatcher:
 	zkappd tx zk-gov vote 1 cosmos13j3mn8n2d3scd2yy3urmw5vqhn53rej6p050np --dispatcher "http://localhost:8080"
-broadcast-sai-vote-via-dispatcher:
+broadcast-charlie-vote-via-dispatcher:
 	zkappd tx zk-gov vote 1 cosmos1mg4t0l2nc98vhjdmg6kzee5wh6uhx9jlfrgfu9 --dispatcher "http://localhost:8080"
-broadcast-teja-vote-via-dispatcher:
+broadcast-david-vote-via-dispatcher:
 	zkappd tx zk-gov vote 1 cosmos1pf0m5ch2673r6lv5lwm2mkyw433xapzx7nuemu --dispatcher "http://localhost:8080"
 
 
-.PHONY: create-proposal-a create-proposal-b broadcast-vishal-vote broadcast-kanna-vote broadcast-sai-vote broadcast-teja-vote broadcast-vishal-vote-via-dispatcher broadcast-kanna-vote-via-dispatcher broadcast-sai-vote-via-dispatcher broadcast-teja-vote-via-dispatcher
+.PHONY: create-proposal-a create-proposal-b broadcast-alice-vote broadcast-bob-vote broadcast-charlie-vote broadcast-david-vote broadcast-alice-vote-via-dispatcher broadcast-bob-vote-via-dispatcher broadcast-charlie-vote-via-dispatcher broadcast-david-vote-via-dispatcher

--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ bash
 Copy code  
 `zkappd  tx zk-gov run-dispatcher --from {key} --keyring-backend test --chain-id {chain-id} -y`
 
-Alternatively, you can run a predefined dispatcher (e.g., Vishal):  
+Alternatively, you can run a predefined dispatcher (e.g., alice):  
 bash  
 Copy code  
-`make run-vishal-dispatcher`
+`make run-alice-dispatcher`
 
 2. This command starts an HTTP server on port `8080` by default. You can change the port using the `--dispatcherPort {port}` flag.
 
@@ -158,13 +158,13 @@ bash
 
 Copy code
 
-`make register-vishal-vote`
+`make register-alice-vote`
 
-`make register-kanna-vote`
+`make register-bob-vote`
 
-`make register-sai-vote`
+`make register-charlie-vote`
 
-`make register-teja-vote`
+`make register-david-vote`
 
 ### **Cast a Vote**
 
@@ -186,9 +186,9 @@ bash
 
 Copy code
 
-`make broadcast-vishal-vote`
+`make broadcast-alice-vote`
 
-`make broadcast-kanna-vote`
+`make broadcast-bob-vote`
 
 #### **With Dispatcher**
 
@@ -204,9 +204,9 @@ bash
 
 Copy code
 
-`make broadcast-sai-vote-via-dispatcher`
+`make broadcast-charlie-vote-via-dispatcher`
 
-`make broadcast-teja-vote-via-dispatcher`
+`make broadcast-david-vote-via-dispatcher`
 
 ### **Query a Proposal**
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Cosmos ZK Voting is a governance voting system designed to ensure voter anonymit
 * **Anonymous Voting:** Protects voter identities using Zero-Knowledge proofs.  
 * **Decentralized:** Built on the Cosmos blockchain for enhanced security and scalability.  
 * **Secure Key Management:** Ensures the safety of prover and verifier keys.  
-* **Relayer Support:** Facilitates seamless vote transactions through a dedicated relayer service.  
+* **dispatcher Support:** Facilitates seamless vote transactions through a dedicated dispatcher service.  
 * **Flexible Proposal Management:** Create and manage governance proposals with ease.
 
 ## **Getting Started**
@@ -30,9 +30,7 @@ bash
 
 Copy code
 
-`git clone https://github.com/your-username/cosmos-zk-voting`
-
-`cd cosmos-zk-voting`
+`git clone https://github.com/vitwit/cosmos-zk-gov`
 
 `git fetch`
 
@@ -52,20 +50,13 @@ Copy code
 
 Initialize and start a local testnet.
 
-**Initialize the Chain:**  
+1. **Initialize and Start the Chain:**  
 Modify the `scripts/init-simapp.sh` script according to your requirements.  
+`make init-simapp` will the run chain.
 bash  
 Copy code  
 `make init-simapp`
 
-1. 
-
-**Start the Testnet:**  
-bash  
-Copy code  
-`zkappd  start`
-
-2. 
 
 ## **ZK Prover and Verifier Keys**
 
@@ -90,36 +81,36 @@ Copy code
 
 * **Optimize Merkle Implementation:** Aim for a constant Merkle tree size of 2^31 and improve update operations from O(n) to O(log n).
 
-## **Relayer**
+## **Dispatcher**
 
-The Relayer is an HTTP server that listens for vote transactions, signs them with a valid chain address, and broadcasts them on-chain.
+The Dispatcher is an HTTP server that listens for vote transactions, signs them with a valid chain address, and broadcasts them on-chain.
 
-### **Why Use a Relayer?**
+### **Why Use a Dispatcher?**
 
-Vote transactions must be sent from a different, unlinkable address than the registered address. Since most users may not have multiple unlinkable addresses, the Relayer serves as an intermediary to handle this securely.
+Vote transactions must be sent from a different, unlinkable address than the registered address. Since most users may not have multiple unlinkable addresses, the dispatcher serves as an intermediary to handle this securely.
 
-**Security Assurance:** The Relayer cannot manipulate transactions because the ZK proof guarantees transaction validity without exposing user secrets.
+**Security Assurance:** The Dispatcher cannot manipulate transactions because the ZK proof guarantees transaction validity without exposing user secrets.
 
-### **Running the Relayer**
+### **Running the Dispatcher**
 
-**Navigate to the Relayer Directory:**  
+**Navigate to the Dispatcher Directory:**  
 bash  
 Copy code  
-`cd /x/zkgov/client/relayer`
+`cd /x/zkgov/client/dispatcher`
 
 1. 
 
-**Start the Relayer:**  
+**Start the dispatcher:**  
 bash  
 Copy code  
-`zkappd  tx zk-gov run-relayer --from {key} --keyring-backend test --chain-id {chain-id} -y`
+`zkappd  tx zk-gov run-dispatcher --from {key} --keyring-backend test --chain-id {chain-id} -y`
 
-Alternatively, you can run a predefined relayer (e.g., Alice):  
+Alternatively, you can run a predefined dispatcher (e.g., Vishal):  
 bash  
 Copy code  
-`make run-alice-relayer`
+`make run-vishal-dispatcher`
 
-2. This command starts an HTTP server on port `8080` by default. You can change the port using the `--relayerPort {port}` flag.
+2. This command starts an HTTP server on port `8080` by default. You can change the port using the `--dispatcherPort {port}` flag.
 
 ## **Transactions**
 
@@ -145,6 +136,12 @@ Copy code
 
 `make create-proposal-a`
 
+**Create Commitments Directory:**  
+bash  
+Copy code  
+`mkdir commitments`
+
+
 ### **Register a Vote**
 
 Register a vote commitment, which will be used later to anonymize the actual vote.
@@ -159,12 +156,11 @@ Alternatively, use predefined make commands:
 
 bash
 
-`mkdir commitments`
 Copy code
 
-`make register-alice-vote`
+`make register-vishal-vote`
 
-`make register-bob-vote`
+`make register-kanna-vote`
 
 `make register-sai-vote`
 
@@ -174,9 +170,9 @@ Copy code
 
 After registering a vote commitment, generate a ZK proof to cast the actual vote. This proof verifies that you know the valid commitment without revealing your identity.
 
-**Important:** The vote transaction must be signed by a different, unlinkable address from the one used to register the vote commitment. Use the Relayer to facilitate this process.
+**Important:** The vote transaction must be signed by a different, unlinkable address from the one used to register the vote commitment. Use the dispatcher to facilitate this process.
 
-#### **Without Relayer**
+#### **Without dispatcher**
 
 bash
 
@@ -190,17 +186,17 @@ bash
 
 Copy code
 
-`make broadcast-alice-vote`
+`make broadcast-vishal-vote`
 
-`make broadcast-bob-vote`
+`make broadcast-kanna-vote`
 
-#### **With Relayer**
+#### **With Dispatcher**
 
 bash
 
 Copy code
 
-`zkappd  tx zk-gov vote [proposal-id] [register-vote-address] --relayer [relayer-address]`
+`zkappd  tx zk-gov vote [proposal-id] [register-vote-address] --dispatcher [dispatcher-address]`
 
 Or use make commands:
 
@@ -208,9 +204,9 @@ bash
 
 Copy code
 
-`make broadcast-sai-vote-via-relayer`
+`make broadcast-sai-vote-via-dispatcher`
 
-`make broadcast-teja-vote-via-relayer`
+`make broadcast-teja-vote-via-dispatcher`
 
 ### **Query a Proposal**
 

--- a/app/app.go
+++ b/app/app.go
@@ -99,9 +99,9 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/spf13/cast"
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov"
-	zkgovKeeper "github.com/vishal-kanna/zk/zk-gov/x/zkgov/keeper"
-	zktypes "github.com/vishal-kanna/zk/zk-gov/x/zkgov/types"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov"
+	zkgovKeeper "github.com/vitwit/cosmos-zk-gov/x/zkgov/keeper"
+	zktypes "github.com/vitwit/cosmos-zk-gov/x/zkgov/types"
 )
 
 const AppName = "App"

--- a/app/sim_bench_test.go
+++ b/app/sim_bench_test.go
@@ -14,7 +14,7 @@ package app_test
 // 	simcli "github.com/cosmos/cosmos-sdk/x/simulation/client/cli"
 // 	"github.com/stretchr/testify/require"
 
-// 	"github.com/vishal-kanna/zk/zk-gov/app"
+// 	"github.com/vitwit/cosmos-zk-gov/app"
 // )
 
 // // Profile with:

--- a/app/zkappd/cmd/commands.go
+++ b/app/zkappd/cmd/commands.go
@@ -12,7 +12,7 @@ import (
 
 	"cosmossdk.io/log"
 	confixcmd "cosmossdk.io/tools/confix/cmd"
-	simapp "github.com/vishal-kanna/zk/zk-gov/app"
+	simapp "github.com/vitwit/cosmos-zk-gov/app"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/debug"

--- a/app/zkappd/cmd/root.go
+++ b/app/zkappd/cmd/root.go
@@ -6,7 +6,7 @@ import (
 	"cosmossdk.io/log"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/spf13/cobra"
-	simapp "github.com/vishal-kanna/zk/zk-gov/app"
+	simapp "github.com/vitwit/cosmos-zk-gov/app"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/config"

--- a/app/zkappd/cmd/root_test.go
+++ b/app/zkappd/cmd/root_test.go
@@ -6,8 +6,8 @@ package cmd_test
 
 // 	"github.com/stretchr/testify/require"
 
-// 	simapp "github.com/vishal-kanna/zk/zk-gov/app"
-// 	"github.com/vishal-kanna/zk/zk-gov/app/zkappd/cmd"
+// 	simapp "github.com/vitwit/cosmos-zk-gov/app"
+// 	"github.com/vitwit/cosmos-zk-gov/app/zkappd/cmd"
 
 // 	"github.com/cosmos/cosmos-sdk/client/flags"
 // 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"

--- a/app/zkappd/cmd/testnet.go
+++ b/app/zkappd/cmd/testnet.go
@@ -15,7 +15,7 @@ import (
 
 	"cosmossdk.io/math"
 	"cosmossdk.io/math/unsafe"
-	simapp "github.com/vishal-kanna/zk/zk-gov/app"
+	simapp "github.com/vitwit/cosmos-zk-gov/app"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"

--- a/app/zkappd/main.go
+++ b/app/zkappd/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	simapp "github.com/vishal-kanna/zk/zk-gov/app"
-	"github.com/vishal-kanna/zk/zk-gov/app/zkappd/cmd"
+	simapp "github.com/vitwit/cosmos-zk-gov/app"
+	"github.com/vitwit/cosmos-zk-gov/app/zkappd/cmd"
 
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 )

--- a/dispatcher/client/client.go
+++ b/dispatcher/client/client.go
@@ -6,20 +6,20 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/types"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/types"
 )
 
-type RelayerClient struct {
+type DispatcherClient struct {
 	Address string
 }
 
-func NewRelayerClient(address string) *RelayerClient {
-	return &RelayerClient{
+func NewdispatcherClient(address string) *DispatcherClient {
+	return &DispatcherClient{
 		Address: address,
 	}
 }
 
-func (relayerClient *RelayerClient) BroadCastTx(msg types.MsgVoteProposal) error {
+func (dispatcherClient *DispatcherClient) BroadCastTx(msg types.MsgVoteProposal) error {
 	// Marshal the message to JSON
 	msgBytes, err := msg.Marshal()
 	if err != nil {
@@ -27,7 +27,7 @@ func (relayerClient *RelayerClient) BroadCastTx(msg types.MsgVoteProposal) error
 	}
 
 	// Create a new POST request
-	url := relayerClient.Address + "/broadCastTransaction"
+	url := dispatcherClient.Address + "/broadCastTransaction"
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(msgBytes))
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP request: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vishal-kanna/zk/zk-gov
+module github.com/vitwit/cosmos-zk-gov
 
 go 1.22.4
 

--- a/proto/sdk/zkgov/v1beta1/query.proto
+++ b/proto/sdk/zkgov/v1beta1/query.proto
@@ -6,7 +6,7 @@ import "google/api/annotations.proto";
 import "sdk/zkgov/v1beta1/zkgov.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package = "github.com/vishal-kanna/zk/zk-gov/x/zkgov/types";
+option go_package = "github.com/vitwit/cosmos-zk-gov/x/zkgov/types";
 
 // Query
 service Query {

--- a/proto/sdk/zkgov/v1beta1/tx.proto
+++ b/proto/sdk/zkgov/v1beta1/tx.proto
@@ -5,7 +5,7 @@ import "cosmos/msg/v1/msg.proto";
 import "sdk/zkgov/v1beta1/zkgov.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package = "github.com/vishal-kanna/zk/zk-gov/x/zkgov/types";
+option go_package = "github.com/vitwit/cosmos-zk-gov/x/zkgov/types";
 
 // Msg service for the zk-giv service
 service Msg {

--- a/proto/sdk/zkgov/v1beta1/zkgov.proto
+++ b/proto/sdk/zkgov/v1beta1/zkgov.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 package sdk.zkgov.v1beta1;
 import "google/protobuf/timestamp.proto";
 
-option go_package = "github.com/vishal-kanna/zk/zk-gov/x/zkgov/types";
+option go_package = "github.com/vitwit/cosmos-zk-gov/x/zkgov/types";
 // commitment
 message Commitment {
   string commitment = 1;

--- a/scripts/init-simapp.sh
+++ b/scripts/init-simapp.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 SIMD_BIN=${SIMD_BIN:=$(which simd 2>/dev/null)}
-ALICE_MNEMONIC="all soap kiwi cushion federal skirt tip shock exist tragic verify lunar shine rely torch please view future lizard garbage humble medal leisure mimic"
-BOB_MNEMONIC="remain then chuckle hockey protect sausage govern curve hobby aisle clinic decline rotate judge this sail broom debris minute buddy buffalo desk pizza invite"
+VISHAL_MNEMONIC="all soap kiwi cushion federal skirt tip shock exist tragic verify lunar shine rely torch please view future lizard garbage humble medal leisure mimic"
+KANNA_MNEMONIC="remain then chuckle hockey protect sausage govern curve hobby aisle clinic decline rotate judge this sail broom debris minute buddy buffalo desk pizza invite"
 SAI_MNEMONIC="festival borrow upon ritual remind song execute chase toward fan neck subway canal throw nothing ticket frown leave thank become extend balcony strike fame"
 TEJA_MNEMONIC="claim infant gather cereal sentence general cheese float hero dwarf miracle oven tide virus question choice say relax similar rice surround deal smooth rival"
 UNKNOWN_MNOMONIC="purpose clutch ill track skate syrup cost among piano elegant close chaos come quit orchard acquire plunge hockey swift tongue salt supreme sting night"
@@ -14,18 +14,18 @@ $SIMD_BIN config set client chain-id demo
 $SIMD_BIN config set client keyring-backend test
 $SIMD_BIN config set app api.enable true
 
-echo $ALICE_MNEMONIC | $SIMD_BIN keys add alice --recover
-echo $BOB_MNEMONIC | $SIMD_BIN keys add bob --recover
+echo $VISHAL_MNEMONIC | $SIMD_BIN keys add vishal --recover
+echo $KANNA_MNEMONIC | $SIMD_BIN keys add kanna --recover
 echo $SAI_MNEMONIC | $SIMD_BIN keys add sai --recover
 echo $TEJA_MNEMONIC | $SIMD_BIN keys add teja --recover
 echo $UNKNOWN_MNOMONIC | $SIMD_BIN keys add unknown --recover
 
 $SIMD_BIN init test --chain-id demo
-$SIMD_BIN genesis add-genesis-account alice 5000000000stake --keyring-backend test
-$SIMD_BIN genesis add-genesis-account bob 5000000000stake --keyring-backend test
+$SIMD_BIN genesis add-genesis-account vishal 5000000000stake --keyring-backend test
+$SIMD_BIN genesis add-genesis-account kanna 5000000000stake --keyring-backend test
 $SIMD_BIN genesis add-genesis-account sai 5000000000stake --keyring-backend test
 $SIMD_BIN genesis add-genesis-account teja 5000000000stake --keyring-backend test
 $SIMD_BIN genesis add-genesis-account unknown 5000000000stake --keyring-backend test
 
-$SIMD_BIN genesis gentx alice 1000000stake --chain-id demo
+$SIMD_BIN genesis gentx vishal 1000000stake --chain-id demo
 $SIMD_BIN genesis collect-gentxs

--- a/scripts/init-simapp.sh
+++ b/scripts/init-simapp.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 SIMD_BIN=${SIMD_BIN:=$(which simd 2>/dev/null)}
-VISHAL_MNEMONIC="all soap kiwi cushion federal skirt tip shock exist tragic verify lunar shine rely torch please view future lizard garbage humble medal leisure mimic"
-KANNA_MNEMONIC="remain then chuckle hockey protect sausage govern curve hobby aisle clinic decline rotate judge this sail broom debris minute buddy buffalo desk pizza invite"
-SAI_MNEMONIC="festival borrow upon ritual remind song execute chase toward fan neck subway canal throw nothing ticket frown leave thank become extend balcony strike fame"
-TEJA_MNEMONIC="claim infant gather cereal sentence general cheese float hero dwarf miracle oven tide virus question choice say relax similar rice surround deal smooth rival"
+ALICE_MNEMONIC="all soap kiwi cushion federal skirt tip shock exist tragic verify lunar shine rely torch please view future lizard garbage humble medal leisure mimic"
+BOB_MNEMONIC="remain then chuckle hockey protect sausage govern curve hobby aisle clinic decline rotate judge this charliel broom debris minute buddy buffalo desk pizza invite"
+CHARLIE_MNEMONIC="festival borrow upon ritual remind song execute chase toward fan neck subway canal throw nothing ticket frown leave thank become extend balcony strike fame"
+DAVID_MNEMONIC="claim infant gather cereal sentence general cheese float hero dwarf miracle oven tide virus question choice say relax similar rice surround deal smooth rival"
 UNKNOWN_MNOMONIC="purpose clutch ill track skate syrup cost among piano elegant close chaos come quit orchard acquire plunge hockey swift tongue salt supreme sting night"
 
 if [ -z "$SIMD_BIN" ]; then echo "SIMD_BIN is not set. Make sure to run make install before"; exit 1; fi
@@ -14,18 +14,18 @@ $SIMD_BIN config set client chain-id demo
 $SIMD_BIN config set client keyring-backend test
 $SIMD_BIN config set app api.enable true
 
-echo $VISHAL_MNEMONIC | $SIMD_BIN keys add vishal --recover
-echo $KANNA_MNEMONIC | $SIMD_BIN keys add kanna --recover
-echo $SAI_MNEMONIC | $SIMD_BIN keys add sai --recover
-echo $TEJA_MNEMONIC | $SIMD_BIN keys add teja --recover
+echo $ALICE_MNEMONIC | $SIMD_BIN keys add alice --recover
+echo $BOB_MNEMONIC | $SIMD_BIN keys add bob --recover
+echo $CHARLIE_MNEMONIC | $SIMD_BIN keys add charlie --recover
+echo $DAVID_MNEMONIC | $SIMD_BIN keys add david --recover
 echo $UNKNOWN_MNOMONIC | $SIMD_BIN keys add unknown --recover
 
 $SIMD_BIN init test --chain-id demo
-$SIMD_BIN genesis add-genesis-account vishal 5000000000stake --keyring-backend test
-$SIMD_BIN genesis add-genesis-account kanna 5000000000stake --keyring-backend test
-$SIMD_BIN genesis add-genesis-account sai 5000000000stake --keyring-backend test
-$SIMD_BIN genesis add-genesis-account teja 5000000000stake --keyring-backend test
+$SIMD_BIN genesis add-genesis-account alice 5000000000stake --keyring-backend test
+$SIMD_BIN genesis add-genesis-account bob 5000000000stake --keyring-backend test
+$SIMD_BIN genesis add-genesis-account charlie 5000000000stake --keyring-backend test
+$SIMD_BIN genesis add-genesis-account david 5000000000stake --keyring-backend test
 $SIMD_BIN genesis add-genesis-account unknown 5000000000stake --keyring-backend test
 
-$SIMD_BIN genesis gentx vishal 1000000stake --chain-id demo
+$SIMD_BIN genesis gentx alice 1000000stake --chain-id demo
 $SIMD_BIN genesis collect-gentxs

--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -32,7 +32,7 @@ cd ..
 # (cd tests/integration/tx/internal; make codegen)
 
 # move proto files to the right places
-cp -r github.com/vishal-kanna/zk/zk-gov/* ./
+cp -r github.com/vitwit/cosmos-zk-gov/* ./
 rm -rf github.com
 
 go mod tidy

--- a/x/zkgov/autocli.go
+++ b/x/zkgov/autocli.go
@@ -2,7 +2,7 @@ package zkgov
 
 // import (
 // 	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
-// 	zkgovv1beta1 "github.com/vishal-kanna/zk/zk-gov/api/sdk/zkgov/v1beta1"
+// 	zkgovv1beta1 "github.com/vitwit/cosmos-zk-gov/api/sdk/zkgov/v1beta1"
 // )
 
 // func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {

--- a/x/zkgov/circuit/circuit.go
+++ b/x/zkgov/circuit/circuit.go
@@ -10,7 +10,7 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/accumulator/merkle"
 	"github.com/consensys/gnark/std/hash/mimc"
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/types"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/types"
 )
 
 // Define the circuit

--- a/x/zkgov/circuit/circuit_test.go
+++ b/x/zkgov/circuit/circuit_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/mimc"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/test"
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/store"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/store"
 )
 
 func GetRandomCommitmentList(size uint64, hFunc hash.Hash) []byte {

--- a/x/zkgov/circuit/localStorage.go
+++ b/x/zkgov/circuit/localStorage.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/types"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/types"
 )
 
 type VoterInfo struct {

--- a/x/zkgov/circuit/read_keys_test.go
+++ b/x/zkgov/circuit/read_keys_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/consensys/gnark/backend/groth16"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/test"
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/store"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/store"
 )
 
 func TestReadingKeys(t *testing.T) {

--- a/x/zkgov/client/cli/query.go
+++ b/x/zkgov/client/cli/query.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"strconv"
 
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/types"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"

--- a/x/zkgov/client/cli/tx.go
+++ b/x/zkgov/client/cli/tx.go
@@ -14,16 +14,16 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slog"
 
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/circuit"
-	relayerCLient "github.com/vishal-kanna/zk/zk-gov/x/zkgov/client/relayer/client"
-	relayerServer "github.com/vishal-kanna/zk/zk-gov/x/zkgov/client/relayer/server"
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/store"
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/types"
+	dispatcherCLient "github.com/vitwit/cosmos-zk-gov/dispatcher/client"
+	dispatcherServer "github.com/vitwit/cosmos-zk-gov/dispatcher/server"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/circuit"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/store"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/types"
 )
 
 var FlagSplit = "split"
-var FlagRelayer = "relayer"
-var FlagRelayerPort = "relayerPort"
+var Flagdispatcher = "dispatcher"
+var FlagdispatcherPort = "dispatcherPort"
 
 // NewTxCmd returns a root CLI command handler for all x/bank transaction commands.
 func NewTxCmd() *cobra.Command {
@@ -39,7 +39,7 @@ func NewTxCmd() *cobra.Command {
 		NewRegisterVoteCmd(),
 		NewCreateProposalCmd(),
 		NewVote(),
-		Relayer(),
+		Dispatcher(),
 	)
 
 	return txCmd
@@ -208,14 +208,14 @@ func NewVote() *cobra.Command {
 				MerkleproofSize:   uint64(merkleproofSize),
 			}
 
-			relayerFlag := cmd.Flag(FlagRelayer)
-			relayerAddress := relayerFlag.Value.String()
-			if relayerAddress == "" {
+			dispatcherFlag := cmd.Flag(Flagdispatcher)
+			dispatcherAddress := dispatcherFlag.Value.String()
+			if dispatcherAddress == "" {
 				return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), &msg)
 			}
 
-			relayerClient := relayerCLient.NewRelayerClient(relayerAddress)
-			err = relayerClient.BroadCastTx(msg)
+			dispatcherClient := dispatcherCLient.NewdispatcherClient(dispatcherAddress)
+			err = dispatcherClient.BroadCastTx(msg)
 			if err != nil {
 				return err
 			}
@@ -225,30 +225,30 @@ func NewVote() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String(FlagRelayer, "", "Broadcast the transaction Relayer end point")
+	cmd.Flags().String(Flagdispatcher, "", "Broadcast the transaction dispatcher end point")
 	flags.AddTxFlagsToCmd(cmd)
 
 	return cmd
 }
 
-func Relayer() *cobra.Command {
+func Dispatcher() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "run-relayer",
-		Short: "relayer will listen to transactions from users, signs them and broadcast them to network",
+		Use:   "run-dispatcher",
+		Short: "dispatcher will listen to transactions from users, signs them and broadcast them to network",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
 			}
 
-			relayer := relayerServer.NewRelayer(&clientCtx, cmd)
-			port := cmd.Flag(FlagRelayerPort).Value.String()
+			dispatcher := dispatcherServer.NewDispatcher(&clientCtx, cmd)
+			port := cmd.Flag(FlagdispatcherPort).Value.String()
 
-			return relayer.Run(port)
+			return dispatcher.Run(port)
 		},
 	}
 
-	cmd.Flags().Uint64(FlagRelayerPort, 8080, "port on which relayer runs")
+	cmd.Flags().Uint64(FlagdispatcherPort, 8080, "port on which dispatcher runs")
 	flags.AddTxFlagsToCmd(cmd)
 	return cmd
 }

--- a/x/zkgov/client/zk/keys.go
+++ b/x/zkgov/client/zk/keys.go
@@ -12,7 +12,7 @@ import (
 	"github.com/consensys/gnark/backend/groth16"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/r1cs"
-	zkcircuit "github.com/vishal-kanna/zk/zk-gov/x/zkgov/circuit"
+	zkcircuit "github.com/vitwit/cosmos-zk-gov/x/zkgov/circuit"
 )
 
 func GenerateZKKeys(merkleProofSize int) {

--- a/x/zkgov/keeper/keeper.go
+++ b/x/zkgov/keeper/keeper.go
@@ -6,9 +6,9 @@ import (
 	cosmosstore "cosmossdk.io/core/store"
 	"github.com/consensys/gnark/backend/groth16"
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/circuit"
-	storeImpl "github.com/vishal-kanna/zk/zk-gov/x/zkgov/store"
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/types"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/circuit"
+	storeImpl "github.com/vitwit/cosmos-zk-gov/x/zkgov/store"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/types"
 
 	storetypes "cosmossdk.io/store/types"
 	"github.com/cosmos/cosmos-sdk/runtime"

--- a/x/zkgov/keeper/keeper_test.go
+++ b/x/zkgov/keeper/keeper_test.go
@@ -18,9 +18,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	"github.com/stretchr/testify/suite"
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov"
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/keeper"
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/types"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/keeper"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/types"
 )
 
 type TestSuite struct {

--- a/x/zkgov/keeper/msg_server.go
+++ b/x/zkgov/keeper/msg_server.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	"context"
 
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/types"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/types"
 )
 
 var _ types.MsgServer = msgServer{}

--- a/x/zkgov/keeper/query_server.go
+++ b/x/zkgov/keeper/query_server.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	"context"
 
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/types"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/types"
 )
 
 var _ types.QueryServer = Keeper{}

--- a/x/zkgov/keeper/query_server_test.go
+++ b/x/zkgov/keeper/query_server_test.go
@@ -3,7 +3,7 @@ package keeper_test
 // import (
 // 	"fmt"
 
-// 	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/types"
+// 	"github.com/vitwit/cosmos-zk-gov/x/zkgov/types"
 // )
 
 // func (s *TestSuite) TestPlanByID() {

--- a/x/zkgov/module.go
+++ b/x/zkgov/module.go
@@ -5,8 +5,8 @@ import (
 
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/client/cli"
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/keeper"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/client/cli"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/keeper"
 
 	"cosmossdk.io/core/appmodule"
 
@@ -15,7 +15,7 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
-	zktypes "github.com/vishal-kanna/zk/zk-gov/x/zkgov/types"
+	zktypes "github.com/vitwit/cosmos-zk-gov/x/zkgov/types"
 )
 
 var (

--- a/x/zkgov/store/commitment.go
+++ b/x/zkgov/store/commitment.go
@@ -5,7 +5,7 @@ import (
 	"context"
 
 	cosmosstore "cosmossdk.io/core/store"
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/types"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/types"
 )
 
 func StoreCommitment(ctx context.Context, store cosmosstore.KVStore, proposalID uint64, commitment string) error {

--- a/x/zkgov/store/merkle.go
+++ b/x/zkgov/store/merkle.go
@@ -10,7 +10,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/mimc"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/accumulator/merkle"
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/types"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/types"
 )
 
 func InitMerkleRoot(ctx context.Context, store cosmosstore.KVStore, proposalID uint64) error {

--- a/x/zkgov/store/nullifier.go
+++ b/x/zkgov/store/nullifier.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 
 	cosmosstore "cosmossdk.io/core/store"
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/types"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/types"
 )
 
 func InitNullifiers(ctx context.Context, store cosmosstore.KVStore, proposalID uint64) error {

--- a/x/zkgov/store/proposal.go
+++ b/x/zkgov/store/proposal.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 
 	cosmosstore "cosmossdk.io/core/store"
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/types"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/types"
 )
 
 func StoreProposal(ctx context.Context, store cosmosstore.KVStore, req types.MsgCreateProposal) (uint64, error) {

--- a/x/zkgov/store/user.go
+++ b/x/zkgov/store/user.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 
 	cosmosstore "cosmossdk.io/core/store"
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/types"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/types"
 )
 
 func InitUsers(ctx context.Context, store cosmosstore.KVStore, proposalID uint64) error {

--- a/x/zkgov/store/vote.go
+++ b/x/zkgov/store/vote.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	cosmosstore "cosmossdk.io/core/store"
-	"github.com/vishal-kanna/zk/zk-gov/x/zkgov/types"
+	"github.com/vitwit/cosmos-zk-gov/x/zkgov/types"
 )
 
 func InitVotes(ctx context.Context, store cosmosstore.KVStore, proposalID uint64) error {


### PR DESCRIPTION
This PR introduces the following updates:

- Replaced real usernames in the README with placeholders Alice and Bob for better clarity.
- Renamed simd to zkappd to reflect updated terminology.
- Updated Relayer references to Dispatcher for consistency.
- Relocated the Dispatcher to the root directory from:
`x/zkgov/client/relayer`
- Updated all relevant links and references across the repository to align with the latest naming conventions.